### PR TITLE
Added a simpler way to generate bindings if needed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,14 @@ serde_yaml = "0.8.7"
 [build-dependencies]
 cc = { version = "1.0.25", features = ["parallel"] }
 
+[build-dependencies.bindgen]
+version = "0.43.1"
+optional = true
+
 [profile.release]
 lto = true
 opt-level = 3
 codegen-units = 1
+
+[features]
+generate_bindings=["bindgen"]

--- a/bindgen.sh
+++ b/bindgen.sh
@@ -1,1 +1,0 @@
-bindgen --no-layout-tests ./vendor/spirv_reflect.h -o ./gen/bindings.rs

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "generate_bindings")]
+extern crate bindgen;
 extern crate cc;
 
 use std::env;
@@ -29,4 +31,23 @@ fn main() {
     }
 
     build.compile("spirv_reflect_cpp");
+
+    generate_bindings("gen/bindings.rs");
 }
+
+#[cfg(feature = "generate_bindings")]
+fn generate_bindings(output_file: &str) {
+    let bindings = bindgen::Builder::default()
+        .header("vendor/spirv_reflect.h")
+        .rustfmt_bindings(true)
+        .layout_tests(false)
+        .generate()
+        .expect("Unable to generate bindings!");
+
+    bindings
+        .write_to_file(std::path::Path::new(output_file))
+        .expect("Unable to write bindings!");
+}
+
+#[cfg(not(feature = "generate_bindings"))]
+fn generate_bindings(_: &str) {}


### PR DESCRIPTION
I replaced ` bindgen.sh` with a more cross-platform way to generate bindings.
This adds an optional dependency on `bindgen`.

It can be used like this:
```
cargo build --features=generate_bindings
```

Or in the `.toml` of someone who has this as a dependency by doing something like:
```toml
[dependencies.spirv-reflect]
version = "0.1"
features=["generate_bindings"]
```

There is an issue with `rustfmt_bindings(true)` not actually formatting the constants at the top of the generated file, I have opened a discussion no the wg-bindged about this since it looks like a bug.