### PR TITLE
Support glsl uniform sampler2D type

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -243,6 +243,9 @@ pub(crate) fn ffi_to_descriptor_type(
 }
 
 pub(crate) fn ffi_to_resource_type(ffi_type: ffi::SpvReflectResourceType) -> ReflectResourceType {
+    const COMBINED: u32 = ffi::SpvReflectResourceType_SPV_REFLECT_RESOURCE_FLAG_SAMPLER
+        | ffi::SpvReflectResourceType_SPV_REFLECT_RESOURCE_FLAG_SRV;
+
     match ffi_type {
         ffi::SpvReflectResourceType_SPV_REFLECT_RESOURCE_FLAG_UNDEFINED => {
             ReflectResourceType::Undefined
@@ -250,6 +253,7 @@ pub(crate) fn ffi_to_resource_type(ffi_type: ffi::SpvReflectResourceType) -> Ref
         ffi::SpvReflectResourceType_SPV_REFLECT_RESOURCE_FLAG_SAMPLER => {
             ReflectResourceType::Sampler
         }
+        COMBINED => ReflectResourceType::CombinedImageSampler,
         ffi::SpvReflectResourceType_SPV_REFLECT_RESOURCE_FLAG_CBV => {
             ReflectResourceType::ConstantBufferView
         }

--- a/src/types/resource.rs
+++ b/src/types/resource.rs
@@ -2,6 +2,7 @@
 pub enum ReflectResourceType {
     Undefined,
     Sampler,
+    CombinedImageSampler,
     ConstantBufferView,
     ShaderResourceView,
     UnorderedAccessView,


### PR DESCRIPTION
This adds support for combined image + sampler resource type, which is expressed by two bitflags set in spirv-reflect library. The match didn't handled that case, which made reflection fail with "not yet implemented" when `sampler2D` type from glsl is present (expressed as `OpTypeSampledImage` in spirv).

The combined flags are originally assigned here
https://github.com/chaoticbob/SPIRV-Reflect/blob/6a68f690663b21a24b8234c1dd7991632f09e5ad/spirv_reflect.c#L1673