### PR TITLE
Forked C++ implementation with fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor"]
 	path = vendor
-	url = https://github.com/Jasper-Bekkers/SPIRV-Reflect.git
+	url = https://github.com/jaynus/SPIRV-Reflect.git
 	branch = nsubtil/NV_ray_tracing


### PR DESCRIPTION
Hello -

The current implementation fork of SPIRV-Reflect which is used causes a crash on reflecting optimized shader builds. I have a PR upstream to that branch, but considering the branch hasn't been touched in a fair while, I am also submitting a PR here to just switch to a different required SPIRV-Reflect fork which contains the desired fix.

You can see the upstream PR here: https://github.com/Jasper-Bekkers/SPIRV-Reflect/pull/1
