### PR TITLE
do not expose ffi_to_string as it is unsound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@ pub mod convert;
 pub mod ffi;
 pub mod types;
 
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn ffi_to_string(ffi: *const ::std::os::raw::c_char) -> String {
+pub(crate) fn ffi_to_string(ffi: *const ::std::os::raw::c_char) -> String {
     if ffi.is_null() {
         String::new()
     } else {


### PR DESCRIPTION
ffi_to_string can easily cause undefined behavior in safe code:

```rust
extern crate spirv_reflect;

fn main() {
    spirv_reflect::ffi_to_string(1 as *const _);
}
```
output:
> Segmentation fault (core dumped)

While simply restricting this to `pub(crate)` is not perfect, it is better than nothing.