### PR TITLE
Fix incorrect cast for cross-platform support (specifically Windows)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ extern crate num_traits;
 #[macro_use]
 extern crate serde_derive;
 
+use std::convert::TryInto;
+
 use num_traits::cast::FromPrimitive;
 
 pub mod convert;
@@ -585,7 +587,7 @@ pub fn create_shader_module(spv_data: &[u8]) -> Result<ShaderModule, &'static st
     let mut module: ffi::SpvReflectShaderModule = unsafe { std::mem::zeroed() };
     let result: ffi::SpvReflectResult = unsafe {
         ffi::spvReflectCreateShaderModule(
-            spv_data.len() as u64,
+            spv_data.len().try_into().unwrap(),
             spv_data.as_ptr() as *const std::os::raw::c_void,
             &mut module,
         )


### PR DESCRIPTION
`size_t` is defined as a c_ulong:

https://github.com/gwihlidal/spirv-reflect-rs/blob/62c41db8ae4fa732425ed843d8358b96f7d07155/gen/bindings.rs#L1615

[Documentation of the type](https://doc.rust-lang.org/std/os/raw/type.c_ulong.html) state that this type can vary between Linux and Windows:

> This type will always be [u32](https://doc.rust-lang.org/std/primitive.u32.html) or [u64](https://doc.rust-lang.org/std/primitive.u64.html). Most notably, many Linux-based systems assume an `u64`, but Windows assumes `u32`.

Hence this is not working on Windows at the moment. This PR fixes this.