### PR TITLE
Add 'ReflectEntryPointLocalSize' to 'ReflectEntryPoint'

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -51,6 +51,11 @@ pub(crate) fn ffi_to_entry_point(ffi_type: &ffi::SpvReflectEntryPoint) -> Reflec
             )
         }
         .to_vec(),
+        local_size: ReflectLocalSize {
+            x: ffi_type.local_size.x,
+            y: ffi_type.local_size.y,
+            z: ffi_type.local_size.z,
+        },
     }
 }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -51,7 +51,7 @@ pub(crate) fn ffi_to_entry_point(ffi_type: &ffi::SpvReflectEntryPoint) -> Reflec
             )
         }
         .to_vec(),
-        local_size: ReflectLocalSize {
+        local_size: ReflectEntryPointLocalSize {
             x: ffi_type.local_size.x,
             y: ffi_type.local_size.y,
             z: ffi_type.local_size.z,

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -168,6 +168,13 @@ pub struct ReflectInterfaceVariable {
     pub(crate) internal_data: *const ffi::SpvReflectInterfaceVariable,
 }
 
+#[derive(Debug, Copy, Clone, Serialize)]
+pub struct ReflectLocalSize {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ReflectEntryPoint {
     pub name: String,
@@ -180,4 +187,5 @@ pub struct ReflectEntryPoint {
     pub descriptor_sets: Vec<ReflectDescriptorSet>,
     pub used_uniforms: Vec<u32>,
     pub used_push_constants: Vec<u32>,
+    pub local_size: ReflectLocalSize,
 }

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -169,7 +169,7 @@ pub struct ReflectInterfaceVariable {
 }
 
 #[derive(Debug, Copy, Clone, Serialize)]
-pub struct ReflectLocalSize {
+pub struct ReflectEntryPointLocalSize {
     pub x: u32,
     pub y: u32,
     pub z: u32,
@@ -187,5 +187,5 @@ pub struct ReflectEntryPoint {
     pub descriptor_sets: Vec<ReflectDescriptorSet>,
     pub used_uniforms: Vec<u32>,
     pub used_push_constants: Vec<u32>,
-    pub local_size: ReflectLocalSize,
+    pub local_size: ReflectEntryPointLocalSize,
 }


### PR DESCRIPTION
Exposes local thread group sizes already available in ffi type to users.

Closes #19 